### PR TITLE
Add multi-axis support to spectrogram viewer

### DIFF
--- a/templates/spectrogram.html
+++ b/templates/spectrogram.html
@@ -370,6 +370,36 @@
         }
         .empty-state .big-icon { font-size: 48px; }
         .empty-state p { font-size: 14px; }
+
+        /* ── Axis selector ── */
+        #axis-selector {
+            display: none;
+            align-items: center;
+            gap: 6px;
+            flex-shrink: 0;
+        }
+        #axis-selector .axis-label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: .07em;
+            color: #6070a0;
+            margin-right: 4px;
+        }
+        .axis-btn {
+            padding: 5px 16px;
+            border-radius: 5px;
+            border: 1px solid #3a4a6a;
+            background: #1a1a35;
+            color: #8090b0;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background .15s, color .15s, border-color .15s;
+        }
+        .axis-btn:hover { background: #1e2a50; color: #c0d0f0; }
+        .axis-btn[data-axis="x"].active { background: #1a2f5a; border-color: #5080d0; color: #7aacf0; }
+        .axis-btn[data-axis="y"].active { background: #1a3a2a; border-color: #40c080; color: #60e0a0; }
+        .axis-btn[data-axis="z"].active { background: #3a2a10; border-color: #d08040; color: #f0a060; }
     </style>
 </head>
 <body>
@@ -462,6 +492,13 @@
             <span class="fi-meta" id="fi-meta"></span>
         </div>
 
+        <div id="axis-selector">
+            <span class="axis-label">Axis</span>
+            <button class="axis-btn active" data-axis="x" onclick="selectAxis('x')">X</button>
+            <button class="axis-btn" data-axis="y" onclick="selectAxis('y')">Y</button>
+            <button class="axis-btn" data-axis="z" onclick="selectAxis('z')">Z</button>
+        </div>
+
         <div id="viz-area">
             <div class="empty-state" id="empty-state">
                 <div class="big-icon">&#127925;</div>
@@ -509,11 +546,18 @@
 'use strict';
 
 // ── State ──────────────────────────────────────────────────────────────────
-let loadedSamples = null;
+let loadedSamples = null;      // single-axis fallback
+let loadedAxes = null;         // { x: Float32Array, y: Float32Array, z: Float32Array }
+let selectedAxis = 'x';        // active axis when multi-axis
 let loadedSampleRate = null;
 let loadedFilename = null;
 let spectrogramFrames = null;  // Float32Array[]
 let spectrogramMeta = null;    // { numFrames, numBins, hopSize, sampleRate, dbMin, dbMax }
+
+function getActiveSamples() {
+    if (loadedAxes) return loadedAxes[selectedAxis];
+    return loadedSamples;
+}
 
 // ── Colormaps ──────────────────────────────────────────────────────────────
 const COLORMAP_STOPS = {
@@ -628,9 +672,11 @@ function hannWindow(N) {
 // ── CSV Parsing ────────────────────────────────────────────────────────────
 function parseCSVText(text) {
     const lines = text.split('\n');
-    const samples = [];
     let detectedSR = null;
-    let headerChecked = false;
+    let headerParsed = false;
+    let colMap = {};
+    let isMulti = false;
+    const data = { x: [], y: [], z: [], t: [], single: [] };
 
     for (const raw of lines) {
         const line = raw.trim();
@@ -642,19 +688,46 @@ function parseCSVText(text) {
             continue;
         }
 
-        const cols = line.split(',');
-        const last = cols[cols.length - 1].trim();
+        const cols = line.split(',').map(c => c.trim());
 
-        if (!headerChecked) {
-            headerChecked = true;
-            if (isNaN(parseFloat(last))) continue; // skip header row
+        if (!headerParsed) {
+            headerParsed = true;
+            if (isNaN(parseFloat(cols[0]))) {
+                // Header row — map column names to indices
+                cols.forEach((name, i) => {
+                    const nl = name.toLowerCase();
+                    if (['t_s','t','time','timestamp'].includes(nl)) colMap.t = i;
+                    else if (['x_g','x','ax','accel_x','acc_x'].includes(nl)) colMap.x = i;
+                    else if (['y_g','y','ay','accel_y','acc_y'].includes(nl)) colMap.y = i;
+                    else if (['z_g','z','az','accel_z','acc_z'].includes(nl)) colMap.z = i;
+                });
+                isMulti = ('x' in colMap && 'y' in colMap && 'z' in colMap);
+                continue;
+            }
         }
 
-        const v = parseFloat(last);
-        if (!isNaN(v)) samples.push(v);
+        if (isMulti) {
+            const xv = parseFloat(cols[colMap.x]);
+            const yv = parseFloat(cols[colMap.y]);
+            const zv = parseFloat(cols[colMap.z]);
+            if (!isNaN(xv) && !isNaN(yv) && !isNaN(zv)) {
+                data.x.push(xv); data.y.push(yv); data.z.push(zv);
+                if ('t' in colMap) { const tv = parseFloat(cols[colMap.t]); if (!isNaN(tv)) data.t.push(tv); }
+            }
+        } else {
+            const v = parseFloat(cols[cols.length - 1]);
+            if (!isNaN(v)) data.single.push(v);
+        }
     }
 
-    return { samples, detectedSR };
+    // Derive sample rate from timestamps when not in metadata
+    if (!detectedSR && data.t.length >= 2) {
+        const dt = (data.t[data.t.length - 1] - data.t[0]) / (data.t.length - 1);
+        if (dt > 0) detectedSR = Math.round(1.0 / dt);
+    }
+
+    if (isMulti) return { axes: { x: data.x, y: data.y, z: data.z }, detectedSR };
+    return { samples: data.single, detectedSR };
 }
 
 // ── STFT Computation ───────────────────────────────────────────────────────
@@ -682,6 +755,8 @@ function computeSTFT(samples, fftSize, hopSize) {
 }
 
 // ── Rendering ──────────────────────────────────────────────────────────────
+const AXIS_COLORS = { x: '#5080d0', y: '#40c090', z: '#d08040', single: '#4080d0' };
+
 function drawWaveform(samples) {
     const canvas = document.getElementById('waveform-canvas');
     const W = canvas.offsetWidth || 800;
@@ -693,16 +768,25 @@ function drawWaveform(samples) {
     ctx.fillStyle = '#0c0c1e';
     ctx.fillRect(0, 0, W, H);
 
-    // Downsample for display
-    const step = Math.max(1, Math.floor(samples.length / W));
+    if (!samples || samples.length === 0) return;
+
     const midY = H / 2;
+    // Zero line
+    ctx.strokeStyle = 'rgba(255,255,255,0.1)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, midY); ctx.lineTo(W, midY);
+    ctx.stroke();
+
+    const step = Math.max(1, Math.floor(samples.length / W));
     let maxAmp = 0;
     for (let i = 0; i < samples.length; i++)
         if (Math.abs(samples[i]) > maxAmp) maxAmp = Math.abs(samples[i]);
     if (maxAmp === 0) maxAmp = 1;
     const scale = (H / 2 - 2) / maxAmp;
 
-    ctx.strokeStyle = '#4080d0';
+    const color = loadedAxes ? AXIS_COLORS[selectedAxis] : AXIS_COLORS.single;
+    ctx.strokeStyle = color;
     ctx.lineWidth = 1;
     ctx.beginPath();
     for (let x = 0; x < W; x++) {
@@ -711,12 +795,6 @@ function drawWaveform(samples) {
         if (x === 0) ctx.moveTo(x, midY - v);
         else ctx.lineTo(x, midY - v);
     }
-    ctx.stroke();
-
-    // Zero line
-    ctx.strokeStyle = 'rgba(255,255,255,0.1)';
-    ctx.beginPath();
-    ctx.moveTo(0, midY); ctx.lineTo(W, midY);
     ctx.stroke();
 }
 
@@ -844,28 +922,71 @@ function setProgress(pct) {
     fill.style.width = pct + '%';
 }
 
-function onSamplesLoaded(samples, sr, filename) {
-    loadedSamples = new Float32Array(samples);
-    loadedSampleRate = sr;
+function onDataLoaded(result, filename) {
     loadedFilename = filename;
+    loadedSampleRate = result.sample_rate || null;
+    spectrogramFrames = null;
+    spectrogramMeta = null;
+
+    if (result.axes) {
+        loadedAxes = {
+            x: new Float32Array(result.axes.x),
+            y: new Float32Array(result.axes.y),
+            z: new Float32Array(result.axes.z),
+        };
+        loadedSamples = null;
+        selectedAxis = 'x';
+        // Show axis selector, reset active button
+        const sel = document.getElementById('axis-selector');
+        sel.style.display = 'flex';
+        document.querySelectorAll('.axis-btn').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.axis === 'x');
+        });
+    } else {
+        loadedAxes = null;
+        loadedSamples = new Float32Array(result.samples);
+        document.getElementById('axis-selector').style.display = 'none';
+    }
+
+    const activeSamples = getActiveSamples();
+    const n = activeSamples.length;
+    const sr = loadedSampleRate;
 
     document.getElementById('empty-state').style.display = 'none';
     document.getElementById('waveform-section').style.display = 'block';
     document.getElementById('spectrogram-section').style.display = 'none';
 
     document.getElementById('fi-name').textContent = filename;
-    const dur = sr ? (samples.length / sr).toFixed(2) + ' s' : 'unknown duration';
+    const dur = sr ? (n / sr).toFixed(2) + ' s' : 'unknown duration';
     const srStr = sr ? sr.toLocaleString() + ' Hz' : 'SR unknown';
+    const axesNote = loadedAxes ? ' · 3 axes (X, Y, Z)' : '';
     document.getElementById('fi-meta').textContent =
-        `${samples.length.toLocaleString()} samples · ${srStr} · ${dur}`;
+        `${n.toLocaleString()} samples · ${srStr} · ${dur}${axesNote}`;
 
     if (sr && !document.getElementById('sample-rate').value)
         document.getElementById('sample-rate').placeholder = `detected: ${sr}`;
 
-    drawWaveform(loadedSamples);
+    drawWaveform(activeSamples);
     document.getElementById('btn-generate').disabled = false;
-    setStatus(`Loaded "${filename}" — ${samples.length.toLocaleString()} samples. Click Generate to render spectrogram.`);
+    setStatus(`Loaded "${filename}" — click Generate to render spectrogram.`);
     setProgress(null);
+}
+
+// Keep backward-compat alias used by old call sites
+function onSamplesLoaded(samples, sr, filename) {
+    onDataLoaded({ samples: Array.from(samples), sample_rate: sr }, filename);
+}
+
+// ── Axis switching ─────────────────────────────────────────────────────────
+function selectAxis(ax) {
+    if (!loadedAxes || selectedAxis === ax) return;
+    selectedAxis = ax;
+    document.querySelectorAll('.axis-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.axis === ax);
+    });
+    drawWaveform(getActiveSamples());
+    // Re-generate spectrogram if one is already shown
+    if (spectrogramFrames) generate();
 }
 
 // ── Load from server ───────────────────────────────────────────────────────
@@ -877,7 +998,7 @@ function loadServerFile(fname) {
         .then(data => {
             if (data.error) { setStatus('Error: ' + data.error); setProgress(null); return; }
             setProgress(80);
-            onSamplesLoaded(data.samples, data.sample_rate, data.filename);
+            onDataLoaded(data, data.filename);
         })
         .catch(err => { setStatus('Network error: ' + err); setProgress(null); });
 }
@@ -889,8 +1010,8 @@ function readLocalFile(file) {
     const reader = new FileReader();
     reader.onload = e => {
         setProgress(60);
-        const { samples, detectedSR } = parseCSVText(e.target.result);
-        onSamplesLoaded(samples, detectedSR, file.name);
+        const parsed = parseCSVText(e.target.result);
+        onDataLoaded({ axes: parsed.axes || null, samples: parsed.samples || null, sample_rate: parsed.detectedSR }, file.name);
     };
     reader.onerror = () => { setStatus('Error reading file.'); setProgress(null); };
     reader.readAsText(file);
@@ -917,7 +1038,8 @@ function handleDrop(evt) {
 
 // ── Generate spectrogram ───────────────────────────────────────────────────
 function generate() {
-    if (!loadedSamples) return;
+    const samples = getActiveSamples();
+    if (!samples) return;
 
     const srOverride = parseInt(document.getElementById('sample-rate').value) || null;
     const sr = srOverride || loadedSampleRate || 44100;
@@ -929,13 +1051,14 @@ function generate() {
     const dbMax = parseFloat(document.getElementById('db-max').value);
     const numBins = fftSize >> 1;
 
-    setStatus('Computing STFT…');
+    const axisLabel = loadedAxes ? ` [${selectedAxis.toUpperCase()} axis]` : '';
+    setStatus(`Computing STFT${axisLabel}…`);
     setProgress(10);
     document.getElementById('btn-generate').disabled = true;
 
     // Defer to let the UI update
     setTimeout(() => {
-        const frames = computeSTFT(loadedSamples, fftSize, hopSize);
+        const frames = computeSTFT(samples, fftSize, hopSize);
         setProgress(70);
 
         spectrogramFrames = frames;
@@ -952,7 +1075,8 @@ function generate() {
         document.getElementById('btn-generate').disabled = false;
 
         const dur = (frames.length * hopSize / sr).toFixed(2);
-        setStatus(`Spectrogram: ${frames.length} frames × ${numBins} bins · ${dur} s · FFT ${fftSize} · overlap ${overlapPct}%`);
+        const axisTag = loadedAxes ? ` · axis ${selectedAxis.toUpperCase()}` : '';
+        setStatus(`Spectrogram: ${frames.length} frames × ${numBins} bins · ${dur} s · FFT ${fftSize} · overlap ${overlapPct}%${axisTag}`);
         setProgress(null);
     }, 30);
 }

--- a/web_app.py
+++ b/web_app.py
@@ -244,11 +244,14 @@ def get_acoustic_data(filename):
         return jsonify({'error': 'File not found'}), 404
 
     samples = []
+    x_samples, y_samples, z_samples, timestamps = [], [], [], []
     sample_rate = None
+    col_map = {}
 
     try:
         with open(filepath, 'r') as f:
-            header_checked = False
+            header_parsed = False
+            is_multi = False
             for line in f:
                 line = line.strip()
                 if not line:
@@ -265,20 +268,53 @@ def get_acoustic_data(filename):
                         except ValueError:
                             pass
                     continue
-                cols = line.split(',')
-                # Skip header row (non-numeric last column)
-                if not header_checked:
-                    header_checked = True
+                cols = [c.strip() for c in line.split(',')]
+                if not header_parsed:
+                    header_parsed = True
                     try:
-                        float(cols[-1])
+                        float(cols[0])
+                        # First column is numeric — no header, use last column fallback
                     except ValueError:
+                        # Header row — map column names
+                        for i, name in enumerate(cols):
+                            nl = name.lower()
+                            if nl in ('t_s', 't', 'time', 'timestamp'):
+                                col_map['t'] = i
+                            elif nl in ('x_g', 'x', 'ax', 'accel_x', 'acc_x'):
+                                col_map['x'] = i
+                            elif nl in ('y_g', 'y', 'ay', 'accel_y', 'acc_y'):
+                                col_map['y'] = i
+                            elif nl in ('z_g', 'z', 'az', 'accel_z', 'acc_z'):
+                                col_map['z'] = i
+                        is_multi = ('x' in col_map and 'y' in col_map and 'z' in col_map)
                         continue
                 try:
-                    samples.append(float(cols[-1]))
+                    if is_multi:
+                        x_samples.append(float(cols[col_map['x']]))
+                        y_samples.append(float(cols[col_map['y']]))
+                        z_samples.append(float(cols[col_map['z']]))
+                        if 't' in col_map and col_map['t'] < len(cols):
+                            timestamps.append(float(cols[col_map['t']]))
+                    else:
+                        samples.append(float(cols[-1]))
                 except (ValueError, IndexError):
                     pass
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+    # Derive sample rate from timestamps when not in metadata
+    if not sample_rate and len(timestamps) >= 2:
+        dt = (timestamps[-1] - timestamps[0]) / (len(timestamps) - 1)
+        if dt > 0:
+            sample_rate = round(1.0 / dt)
+
+    if x_samples:
+        return jsonify({
+            'filename': filename,
+            'axes': {'x': x_samples, 'y': y_samples, 'z': z_samples},
+            'num_samples': len(x_samples),
+            'sample_rate': sample_rate,
+        })
 
     return jsonify({
         'filename': filename,


### PR DESCRIPTION
- Backend: detect t_s,x_g,y_g,z_g CSV format, parse all three axes, derive sample rate from timestamps when not in metadata comments, return axes:{x,y,z} in API response
- Frontend: auto-detect multi-axis data; show X/Y/Z selector buttons that appear only for multi-axis files; switching axes redraws the waveform immediately and regenerates the spectrogram if one exists; waveform trace color matches the active axis; single-axis CSVs continue to work unchanged

https://claude.ai/code/session_01JVxKFWeyXvicwRzXCfe51e